### PR TITLE
showcase bad test

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
 		"prepare": "husky install",
 		"prepublishOnly": "pnpm build",
 		"test": "vitest",
-		"migrate-v10": "tsx src/bin.ts"
+		"migrate-v10": "tsx src/bin.ts",
+		"migrate-test": "pnpm migrate-v10 --tsconfig-path ./test/tsconfig.test.json"
 	},
 	"dependencies": {
 		"clipanion": "3.2.0-rc.12",

--- a/test/server.ts
+++ b/test/server.ts
@@ -18,6 +18,15 @@ const appRouter = router()
 			}
 		},
 	})
+	.query('post.byId', {
+		input: z.object({ id: z.string() }),
+		resolve: ({ input }) => {
+			return {
+				id: input.id,
+				title: 'hello',
+			}
+		},
+	})
 	.merge('example', exampleRouter)
 	.middleware(async ({ ctx, next }) => {
 		if (!ctx.user?.isAdmin) {


### PR DESCRIPTION
Only picking the **last** defined procedure on `post.x` -- `post.create` disappears

Output becomes


```tsx
import { router, TRPCError } from '@trpc/server'
import { z } from 'zod'
import { exampleRouter } from './example.js'

const middleware_300161978 = t.middleware(async ({ ctx, next }) => {
    if (!ctx.user?.isAdmin) {
        throw new TRPCError({ code: 'UNAUTHORIZED' })
    }
    return next()
});
const procedure_300161978 = t.procedure.use(middleware_300161978);
const appRouter = t.router({
    hello: t.procedure.output(z.string()).query(() => {
        return 'world'
    }),
    post: t.router({
        byId: t.procedure.input(z.object({ id: z.string() })).query(({ input }) => {
        			return {
        				id: input.id,
        				title: 'hello',
        			}
        		}),
    }),
    secretPlace: procedure_300161978.query(() => {
        return 'a key'
    }),
    example: exampleRouter,
})


```
