### PR TITLE
camel-case procedure identifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,12 +40,14 @@
 	},
 	"dependencies": {
 		"clipanion": "3.2.0-rc.12",
+		"lodash-es": "^4.17.21",
 		"ts-morph": "16.0.0",
 		"typanion": "^3.12.0"
 	},
 	"devDependencies": {
 		"@sachinraja/eslint-config": "0.1.1",
 		"@trpc/server": "9.27.2",
+		"@types/lodash-es": "^4.17.6",
 		"@types/node": "18.7.14",
 		"dprint": "0.31.1",
 		"eslint": "8.23.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,11 +3,13 @@ lockfileVersion: 5.4
 specifiers:
   '@sachinraja/eslint-config': 0.1.1
   '@trpc/server': 9.27.2
+  '@types/lodash-es': ^4.17.6
   '@types/node': 18.7.14
   clipanion: 3.2.0-rc.12
   dprint: 0.31.1
   eslint: 8.23.0
   husky: 8.0.1
+  lodash-es: ^4.17.21
   nano-staged: 0.8.0
   npm-run-all: 4.1.5
   ts-morph: 16.0.0
@@ -21,12 +23,14 @@ specifiers:
 
 dependencies:
   clipanion: 3.2.0-rc.12_typanion@3.12.0
+  lodash-es: 4.17.21
   ts-morph: 16.0.0
   typanion: 3.12.0
 
 devDependencies:
   '@sachinraja/eslint-config': 0.1.1_yqf6kl63nyoq5megxukfnom5rm
   '@trpc/server': 9.27.2
+  '@types/lodash-es': 4.17.6
   '@types/node': 18.7.14
   dprint: 0.31.1
   eslint: 8.23.0
@@ -205,6 +209,16 @@ packages:
 
   /@types/json-schema/7.0.11:
     resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
+    dev: true
+
+  /@types/lodash-es/4.17.6:
+    resolution: {integrity: sha512-R+zTeVUKDdfoRxpAryaQNRKk3105Rrgx2CFRClIgRGaqDTdjsm8h6IYA8ir584W3ePzkZfst5xIgDwYrlh9HLg==}
+    dependencies:
+      '@types/lodash': 4.14.186
+    dev: true
+
+  /@types/lodash/4.14.186:
+    resolution: {integrity: sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==}
     dev: true
 
   /@types/node/18.7.14:
@@ -1788,6 +1802,10 @@ packages:
     dependencies:
       p-locate: 5.0.0
     dev: true
+
+  /lodash-es/4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+    dev: false
 
   /lodash.merge/4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,12 @@ import {
 	VariableDeclarationKind,
 } from 'ts-morph'
 import { MigrateConfig } from './types.js'
-import { getStringHash, getStringLiteralOrText, writeValueFromObjectLiteralElement } from './utils.js'
+import {
+	getStringHash,
+	getStringLiteralOrText,
+	normalizeProcedurePath,
+	writeValueFromObjectLiteralElement,
+} from './utils.js'
 
 interface ProcedureUnit {
 	tag: 'procedure'
@@ -212,7 +217,8 @@ const writeShape = (
 		config: MigrateConfig
 	},
 ) => {
-	const { writer, procedureOrRouter, path, middlewaresProcedureIdMap, config } = options
+	const { writer, procedureOrRouter, path: rawPath, middlewaresProcedureIdMap, config } = options
+	const path = rawPath ? normalizeProcedurePath(rawPath) : undefined
 
 	if ('procedure' in procedureOrRouter) {
 		if (path) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { camelCase } from 'lodash-es'
 import { CodeBlockWriter, Node, ObjectLiteralElementLike, SyntaxKind } from 'ts-morph'
 
 export const getStringFromStringOrArrayLiteral = (node: Node) => {
@@ -52,3 +53,11 @@ export const getDefinedProperties = <TObject extends Record<string, unknown>>(ob
 		Object.entries(object).filter(([, v]) => v !== undefined),
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	) as any
+
+/**
+ * Normalizes a procedure path so that it can be used as a symbol.
+ *
+ * @param path The path to normalize
+ * @returns The normalized path
+ */
+export const normalizeProcedurePath = (path: string) => path.split('.').map((it) => camelCase(it)).join('.')


### PR DESCRIPTION
closes #18

pretty simple solution. if you have issues with me introducing `lodash-es` as a dependency, I'm happy to implement a rudimentary `camelCase` myself, but I figured i'd rather have the thoroughness of lodash's case-altering logic (I find it quite reliable)

also fixes a bug I found when `useQuery` was used with an array but with only a path and no input (i.e. `useQuery(['my.query'])`)